### PR TITLE
firstlevel: added --minimum_unmasked_neighbors option

### DIFF
--- a/oceanproc/firstlevel/tests/test_run_glm.py
+++ b/oceanproc/firstlevel/tests/test_run_glm.py
@@ -10,11 +10,13 @@ from scipy import signal
 TR = 1.2
 
 # define some fixtures
+
+
 @pytest.fixture
 def confounds_df():
-    df = pd.DataFrame(data={"framewise_displacement": np.random.rand(50), 
+    df = pd.DataFrame(data={"framewise_displacement": np.random.rand(50),
                             "global_signal": np.random.rand(50) * 5000,
-                            "volterra": np.ones(50)}) 
+                            "volterra": np.ones(50)})
     return df
 
 
@@ -31,17 +33,19 @@ def random_fdata():
 
 @pytest.fixture
 def random_eventdf():
-    d = {"trial_type": random.choices(('a','b','c'), k=50), #<-- 50 random a, b, or c
-         "onset": np.linspace(0, 60, 50), #<-- 50 intervals of 1.2 seconds}
-         "duration": np.ones(50)} #<-- 50 random correct, incorrect
+    d = {"trial_type": random.choices(('a','b','c'), k=50),  # <-- 50 random a, b, or c
+         "onset": np.linspace(0, 60, 50),  # <-- 50 intervals of 1.2 seconds}
+         "duration": np.ones(50)}  # <-- 50 random correct, incorrect
     return pd.DataFrame(data=d)
+
 
 @pytest.fixture
 def random_signaldf():
-    d = {"flat_signal": np.ones(50) * 50, 
+    d = {"flat_signal": np.ones(50) * 50,
          "random_signal": np.random.rand(50) * 50,
          "sine_signal": np.sin(np.linspace(-np.pi, np.pi, 50))}
     return pd.DataFrame(data=d)
+
 
 def test_make_option():
     assert make_option(True) == " "
@@ -70,22 +74,23 @@ def test_make_noise_ts(tmp_path,
     confounds_file = tmp_path / "tmp.tsv"
     confounds_df.to_csv(confounds_file, sep='\t')
     noise_ts = make_noise_ts(confounds_file,
-                       confounds_columns,
-                       demean,
-                       linear_trend,
-                       spike_threshold,
-                       volterra_expansion,
-                       volterra_columns)
+                             confounds_columns,
+                             demean,
+                             linear_trend,
+                             spike_threshold,
+                             volterra_expansion,
+                             volterra_columns)
     if spike_threshold:
         assert spike_threshold > 0
         spike_column_num = (noise_ts.loc[:, "framewise_displacement"] > spike_threshold).sum()
         assert len([col for col in noise_ts.columns if "spike" in col]) == spike_column_num
-       
+
     assert "volterra_expansion" in locals() and "volterra_columns" in locals()
     if volterra_expansion:
         for i in range(volterra_expansion):
             # Check that each volterra column has been shifted appropriately
             assert (noise_ts.loc[0:i, f"volterra_{i+1}"] == 0).all()
+
 
 @pytest.mark.parametrize("fir,hrf,fir_list,hrf_list",
                          [(None, None, None, None),
@@ -95,14 +100,14 @@ def test_make_noise_ts(tmp_path,
                           (3, (5, 10), ['a','b'], None),
                           (3, (5, 10), None, ['a','b']),
                           (3, (5, 10), ['a','b'], ['a','b'])])
-def test_events_to_design(tmp_path, 
-                          random_fdata, 
+def test_events_to_design(tmp_path,
+                          random_fdata,
                           random_eventdf,
                           fir,
                           hrf,
                           fir_list,
                           hrf_list):
-    def run(): 
+    def run():
         return events_to_design(func_data,
                                 TR,
                                 event_file,
@@ -114,17 +119,17 @@ def test_events_to_design(tmp_path,
     event_file = tmp_path / "events.tsv"
     random_eventdf.to_csv(event_file, sep='\t')
     # both fir and hrf specified, but no list of columns for either
-    if (fir and hrf) and not (fir_list or hrf_list): 
+    if (fir and hrf) and not (fir_list or hrf_list):
         with pytest.raises(RuntimeError):
             events_df, run_conditions = run()
         return
     # fir_list, hrf_list have overlapping column names
-    elif (fir_list and hrf_list) and not set(fir_list).isdisjoint(hrf_list): 
+    elif (fir_list and hrf_list) and not set(fir_list).isdisjoint(hrf_list):
         with pytest.raises(RuntimeError):
             events_df, run_conditions = run()
         return
     events_df, run_conditions = run()
-    if fir_list: # Check if a_00, a_01, ... a_nn exist, and if the number of a columns matches the fir int
+    if fir_list:  # Check if a_00, a_01, ... a_nn exist, and if the number of a columns matches the fir int
         pattern = re.compile(f"{fir_list[0]}_\\d\\d")
         assert len([col for col in events_df.columns if re.match(pattern, col)]) == fir
 
@@ -149,17 +154,17 @@ def test_nuisance_regression(tmp_path,
     confounds_file = tmp_path / "tmp.tsv"
     confounds_df.to_csv(confounds_file, sep='\t')
     noise_ts = make_noise_ts(confounds_file,
-                       confounds_columns,
-                       demean,
-                       linear_trend,
-                       spike_threshold,
-                       volterra_expansion,
-                       volterra_columns)
+                             confounds_columns,
+                             demean,
+                             linear_trend,
+                             spike_threshold,
+                             volterra_expansion,
+                             volterra_columns)
     data_minus_residuals = nuisance_regression(random_fdata, noise_ts)
-     
 
-# def test_hrf_convolve_features(tmp_path, 
-                               # random_signaldf):
+
+# def test_hrf_convolve_features(tmp_path,
+    # random_signaldf):
     # cfeats = hrf_convolve_features(random_signaldf)
     # for col in random_signaldf.columns:
-        # recovered, remainder = signal.deconvolve(cfeats[col], )
+    # recovered, remainder = signal.deconvolve(cfeats[col], )


### PR DESCRIPTION
this will force every timepoint to have at least N unmasked neighboring timepoints on either side. timepoints at the beginning/end of the timeseries will be padded with the appropriate number of neighbors