### PR TITLE
Dev/psc

### DIFF
--- a/oceanproc/firstlevel/run_glm.py
+++ b/oceanproc/firstlevel/run_glm.py
@@ -722,7 +722,7 @@ def main():
                                   help="Path to a dlabel file to use for parcellation of a dtseries")
 
     args = parser.parse_args()
-
+    
     if args.hrf is not None and args.fir is not None:
         if not args.fir_vars or not args.hrf_vars:
             parser.error("Must specify variables to apply each model to if using both types of models")

--- a/oceanproc/firstlevel/run_glm.py
+++ b/oceanproc/firstlevel/run_glm.py
@@ -540,7 +540,7 @@ def create_final_design(data_list: list[npt.ArrayLike],
 def massuni_linGLM(func_data: npt.ArrayLike,
                    design_matrix: pd.DataFrame,
                    mask: npt.ArrayLike,
-                   stdscale: str = "both"):
+                   stdscale: bool):
     """
     Compute the mass univariate GLM.
 
@@ -557,7 +557,6 @@ def massuni_linGLM(func_data: npt.ArrayLike,
     assert mask.shape[0] == func_data.shape[0], "the mask must be the same length as the functional data"
     assert mask.dtype == bool
 
-    stdscale = stdscale in ("seslevel", "both")
     # apply the mask to the data
     design_matrix = design_matrix.to_numpy()
     if stdscale:
@@ -1097,7 +1096,8 @@ def main():
                 nuisance_betas, func_data_residuals = massuni_linGLM(
                     func_data=func_data,
                     design_matrix=noise_regression_df,
-                    mask=nuisance_mask
+                    mask=nuisance_mask,
+                    stdscale=args.stdscale_glm in ("both", "runlevel")
                 )
 
                 run_map["data_resids"] = func_data_residuals
@@ -1224,7 +1224,7 @@ def main():
             func_data=final_func_data,
             design_matrix=final_design_unmasked,
             mask=final_high_motion_mask,
-            stdscale=args.stdscale_glm
+            stdscale=args.stdscale_glm in ("seslevel", "both")
         )
         # if flags.debug:
         #     variance_img, img_suffix = create_image(

--- a/oceanproc/firstlevel/run_glm.py
+++ b/oceanproc/firstlevel/run_glm.py
@@ -1053,15 +1053,6 @@ def main():
                     )
                     unmodified_output_dir_contents.discard(cleaned_filename)
 
-            # demean and detrend if filtering is requested
-            # if (args.highpass is not None or args.lowpass is not None):
-            #     if "mean" not in args.nuisance_regression:
-            #         logger.warning("High-, low-, or band-pass specified, but mean not specified as nuisance regressor -- adding this in automatically")
-            #         args.nuisance_regression.append("mean")
-            #     if "trend" not in args.nuisance_regression:
-            #         logger.warning("High-, low-, or band-pass specified, but trend not specified as nuisance regressor -- adding this in automatically")
-            #         args.nuisance_regression.append("trend")
-
             # nuisance regression if specified
             if len(args.nuisance_regression) > 0:
                 nuisance_mask = np.ones(shape=(func_data.shape[0],)).astype(bool)
@@ -1230,33 +1221,6 @@ def main():
             mask=final_high_motion_mask,
             stdscale=args.stdscale_glm in ("seslevel", "both")
         )
-        # if flags.debug:
-        #     variance_img, img_suffix = create_image(
-        #         data=variance_arr[np.newaxis, :],
-        #         imagetype=imagetype,
-        #         brain_mask=brain_mask,
-        #         tr=tr,
-        #         header=img_header
-        #     )
-        #     variance_img_filename = args.output_dir / f"{file_name_base}_desc-model-{model_type}-stdscale-variance{img_suffix}"
-        #     logger.info(f" saving session-level variance (of unmasked frames) to file: {variance_img_filename}")
-        #     nib.save(
-        #         variance_img,
-        #         variance_img_filename
-        #     )
-        #     mean_img, img_suffix = create_image(
-        #         data=mean_arr[np.newaxis, :],
-        #         imagetype=imagetype,
-        #         brain_mask=brain_mask,
-        #         tr=tr,
-        #         header=img_header
-        #     )
-        #     mean_img_filename = args.output_dir / f"{file_name_base}_desc-model-{model_type}-stdscale-mean{img_suffix}"
-        #     logger.info(f" saving session-level mean (of unmasked frames) to file: {mean_img_filename}")
-        #     nib.save(
-        #         mean_img,
-        #         mean_img_filename
-        #     )
         step_count += 1
         # save out the beta values
         logger.info("saving betas from GLM into files")

--- a/oceanproc/firstlevel/run_glm.py
+++ b/oceanproc/firstlevel/run_glm.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import numpy as np
 import sys
 import os
 from pathlib import Path
@@ -8,9 +7,7 @@ import numpy.typing as npt
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
 import nibabel as nib
-# from nilearn.glm.first_level import FirstLevelModel
-# from nilearn.plotting import plot_design_matrix
-# import matplotlib.pyplot as plt
+import numpy as np
 import nilearn.masking as nmask
 from nilearn.signal import butterworth, _handle_scrubbed_volumes
 from scipy import signal
@@ -543,7 +540,7 @@ def create_final_design(data_list: list[npt.ArrayLike],
 def massuni_linGLM(func_data: npt.ArrayLike,
                    design_matrix: pd.DataFrame,
                    mask: npt.ArrayLike,
-                   stdscale: bool = False):
+                   stdscale: str = "both"):
     """
     Compute the mass univariate GLM.
 
@@ -560,6 +557,7 @@ def massuni_linGLM(func_data: npt.ArrayLike,
     assert mask.shape[0] == func_data.shape[0], "the mask must be the same length as the functional data"
     assert mask.dtype == bool
 
+    stdscale = stdscale in ("seslevel", "both")
     # apply the mask to the data
     design_matrix = design_matrix.to_numpy()
     if stdscale:
@@ -723,7 +721,7 @@ def main():
                                   help="The confound columns to include in the expansion. Must be specifed with the '--volterra_lag' option.")
     config_arguments.add_argument("--parcellate", "-parc", type=Path,
                                   help="Path to a dlabel file to use for parcellation of a dtseries")
-    config_arguments.add_argument("--stdscale_glm", action="store_true",
+    config_arguments.add_argument("--stdscale_glm", choices=["runlevel", "seslevel", "both", "none"], default="both",
                                   help="Option to standard scale concatenated timeseries before running final GLM (after masking & nuisance regression)")
 
     args = parser.parse_args()

--- a/oceanproc/firstlevel/run_glm.py
+++ b/oceanproc/firstlevel/run_glm.py
@@ -23,6 +23,8 @@ import argparse
 import datetime
 from textwrap import dedent
 
+np.random.default_rng(seed=1234)
+
 """
 TODO:
     * Find good way to pass hrf peak and undershoot variables

--- a/oceanproc/firstlevel/run_glm.py
+++ b/oceanproc/firstlevel/run_glm.py
@@ -20,7 +20,6 @@ import argparse
 import datetime
 from textwrap import dedent
 
-np.random.default_rng(seed=1234)
 
 """
 TODO:
@@ -603,6 +602,7 @@ def autogenerate_mask(mask_files: list[Path], output_path: Path) -> Path:
 
 
 def main():
+
     parser = OceanParser(
         prog="oceanfla",
         description="Ocean Labs first level analysis",
@@ -722,8 +722,12 @@ def main():
                                   help="Path to a dlabel file to use for parcellation of a dtseries")
     config_arguments.add_argument("--stdscale_glm", choices=["runlevel", "seslevel", "both", "none"], default="both",
                                   help="Option to standard scale concatenated timeseries before running final GLM (after masking & nuisance regression)")
+    config_arguments.add_argument("--np_random_seed", type=int, default=42,
+                                  help="Set Numpy seed (default is 42)")
 
     args = parser.parse_args()
+
+    np.random.default_rng(seed=args.np_random_seed)
 
     if args.hrf is not None and args.fir is not None:
         if not args.fir_vars or not args.hrf_vars:

--- a/oceanproc/preprocessing_wrapper.py
+++ b/oceanproc/preprocessing_wrapper.py
@@ -108,7 +108,7 @@ def run_preprocessing(subject:str,
     bids_mount = "/data"
     derivs_mount = "/out"
     work_mount = "/work"
-    preproc_command = f"""docker run --rm -it -u {uid}:{gid}
+    preproc_command = f"""docker run --rm -i -u {uid}:{gid}
                             -v {license_file.resolve()}:{license_mount}:ro
                             -v {bids_path.resolve()}:{bids_mount}:ro
                             -v {derivs_path.resolve()}:{derivs_mount}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pybids>=0.16.3",
 ]
 name = "oceanproc"
-version = "1.1.4"
+version = "1.1.5"
 description = "MRI preprocessing for WUSTL Ocean labs"
 readme = "README.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1210,7 +1210,7 @@ wheels = [
 
 [[package]]
 name = "oceanproc"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "asttokens" },


### PR DESCRIPTION
New flags added:

- `--min_average_tnsr`: throw out BOLD runs below a given whole-brain-average TNSR before analysis
- `--min_run_threshold`: don't run `oceanfla` if there are less than N runs remaining after exclusion criteria
- `--stdscale_glm`: options between `runlevel`, `seslevel`, `both`, or `none` -- setting `runlevel` will z-score at the run level during nuisance regression, `seslevel` will z-score the entire concatenated timeseries before the final GLM, `both` will perform both `runlevel` and `seslevel` z-scoring, `none` does neither.
- `--percent_change`: express BOLD signal as percent signal change instead
- `--np_random_seed`: sets the seed for Numpy's random number generator

The `--debug` flag will now also save out intermediate outputs after each preparation step before the final GLM, and include the step number in the outputted filename.