### PR TITLE
FEAT: limit the scope of PyBids indexer

### DIFF
--- a/oceanproc/ocean_proc.py
+++ b/oceanproc/ocean_proc.py
@@ -275,6 +275,8 @@ def main():
         with open(bids_path / ".bidsignore", "r") as f:
             ignore_list.extend(f.readlines())
     ignore_list = list(set(ignore_list))
+    other_sub_paths = [p.name for p in bids_path.glob("sub-*") if args.subject not in p.name and p.is_dir()]
+    ignore_list.extend(other_sub_paths)
     bids_layout = BIDSLayout(args.bids_path, validate=False, indexer=BIDSLayoutIndexer(ignore=ignore_list, validate=False))
 
     ##### Remove the scans marked as 'unusable' #####


### PR DESCRIPTION
For large BIDS-formatted raw datasets, using `pybids`'s default indexing behavior can result in lots of time being taken performing a full walk of the directory tree, instead of limiting its scope to just the subject queued for processing -- this should vastly improve startup speed (especially when the underlying filesystem is having performance issues)